### PR TITLE
feat: 전체 책 정보 조회 기능 추가

### DIFF
--- a/src/main/java/sogorae/auth/config/AuthenticationPrincipalConfig.java
+++ b/src/main/java/sogorae/auth/config/AuthenticationPrincipalConfig.java
@@ -26,7 +26,7 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new LoginInterceptor(jwtProvider))
           .addPathPatterns("/api/**")
-          .excludePathPatterns("/api/members", "/api/auth/login");
+          .excludePathPatterns("/api/members", "/api/auth/login", "/api/");
     }
 
     @Override

--- a/src/main/java/sogorae/auth/support/LoginInterceptor.java
+++ b/src/main/java/sogorae/auth/support/LoginInterceptor.java
@@ -19,6 +19,16 @@ public class LoginInterceptor implements HandlerInterceptor {
         if (request.getMethod().equals("POST") && request.getRequestURI().equals("/api/members")) {
             return true;
         }
+
+
+        if (request.getMethod().equals("GET") && request.getRequestURI().equals("/api/books")) {
+            return true;
+        }
+
+        if (request.getMethod().equals("GET") && request.getRequestURI().startsWith("/api/books/")) {
+            return true;
+        }
+
         String token = AuthorizationExtractor.extract(request);
         if (!jwtProvider.isValid(token)) {
             throw new InvalidTokenException();

--- a/src/main/java/sogorae/billage/controller/BookController.java
+++ b/src/main/java/sogorae/billage/controller/BookController.java
@@ -1,6 +1,9 @@
 package sogorae.billage.controller;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sogorae.auth.dto.LoginMember;
 import sogorae.auth.support.AuthenticationPrincipal;
+import sogorae.billage.domain.Book;
 import sogorae.billage.dto.BookRegisterRequest;
 import sogorae.billage.dto.BookResponse;
 import sogorae.billage.service.BookService;
@@ -44,5 +48,13 @@ public class BookController {
     public ResponseEntity<BookResponse> findOne(@PathVariable Long bookId) {
         BookResponse response = BookResponse.from(bookService.findById(bookId));
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<BookResponse>> findAll() {
+        List<BookResponse> bookResponses = bookService.findAll().stream()
+            .map(BookResponse::from)
+            .collect(Collectors.toList());
+        return ResponseEntity.ok(bookResponses);
     }
 }

--- a/src/main/java/sogorae/billage/repository/BookRepository.java
+++ b/src/main/java/sogorae/billage/repository/BookRepository.java
@@ -1,5 +1,7 @@
 package sogorae.billage.repository;
 
+import java.util.List;
+
 import sogorae.billage.domain.Book;
 
 public interface BookRepository {
@@ -7,4 +9,6 @@ public interface BookRepository {
     Long save(Book book);
 
     Book findById(Long id);
+
+    List<Book> findAll();
 }

--- a/src/main/java/sogorae/billage/repository/HibernateBookRepository.java
+++ b/src/main/java/sogorae/billage/repository/HibernateBookRepository.java
@@ -1,5 +1,6 @@
 package sogorae.billage.repository;
 
+import java.util.List;
 import java.util.Objects;
 
 import javax.persistence.EntityManager;
@@ -33,5 +34,10 @@ public class HibernateBookRepository implements BookRepository {
         if (Objects.isNull(book)) {
             throw new BookNotFoundException();
         }
+    }
+
+    public List<Book> findAll() {
+        String jpql = "SELECT b from Book b";
+        return em.createQuery(jpql, Book.class).getResultList();
     }
 }

--- a/src/main/java/sogorae/billage/service/BookService.java
+++ b/src/main/java/sogorae/billage/service/BookService.java
@@ -1,5 +1,7 @@
 package sogorae.billage.service;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,5 +40,9 @@ public class BookService {
         Member member = memberRepository.findByEmail(email);
         Book book = bookRepository.findById(bookId);
         book.allowRent(member);
+    }
+
+    public List<Book> findAll() {
+        return bookRepository.findAll();
     }
 }

--- a/src/test/java/sogorae/billage/acceptance/BookAcceptanceTest.java
+++ b/src/test/java/sogorae/billage/acceptance/BookAcceptanceTest.java
@@ -3,6 +3,8 @@ package sogorae.billage.acceptance;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.List;
+
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +14,7 @@ import sogorae.auth.dto.LoginMemberRequest;
 import sogorae.auth.dto.LoginResponse;
 import sogorae.billage.AcceptanceTest;
 import sogorae.billage.dto.BookRegisterRequest;
+import sogorae.billage.dto.BookResponse;
 import sogorae.billage.dto.MemberSignUpRequest;
 
 public class BookAcceptanceTest extends AcceptanceTest {
@@ -110,6 +113,75 @@ public class BookAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = postWithToken(
           "/api/books/" + bookId + "/rents", token, email);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("책 id 를 받아 단일 책 정보를 조회한다.")
+    void findOne() {
+        // given
+        String email = "beom@naver.com";
+        String nickname = "범고래";
+        String password = "12345678";
+        MemberSignUpRequest request = new MemberSignUpRequest(email, nickname, password);
+        post("/api/members", request);
+
+        LoginMemberRequest loginMemberRequest = new LoginMemberRequest(email, password);
+        String token = getTokenWithLogin(loginMemberRequest);
+
+        BookRegisterRequest bookRegisterRequest = new BookRegisterRequest("책 제목", "image_url",
+            "책 상세 메세지", "책 위치");
+        ExtractableResponse<Response> bookRegisterResponse = postWithToken("/api/books/", token, bookRegisterRequest);
+
+        String[] locations = bookRegisterResponse.header("Location").split("/");
+        long bookId = Long.parseLong(locations[locations.length - 1]);
+
+        // when
+        ExtractableResponse<Response> response = get("/api/books/" + bookId);
+
+        // then
+        BookResponse expected = new BookResponse(nickname, "책 제목", "image_url",
+            "책 상세 메세지", "책 위치");
+        BookResponse actual = response.body().as(BookResponse.class);
+
+        assertThat(actual).usingRecursiveComparison()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("전체 책 정보를 조회한다.")
+    void findAll() {
+        // given
+        String email = "beom@naver.com";
+        String nickname = "범고래";
+        String password = "12345678";
+        MemberSignUpRequest request = new MemberSignUpRequest(email, nickname, password);
+        post("/api/members", request);
+
+        LoginMemberRequest loginMemberRequest = new LoginMemberRequest(email, password);
+        String token = getTokenWithLogin(loginMemberRequest);
+
+        BookRegisterRequest bookRegisterRequest = new BookRegisterRequest("책 제목", "image_url",
+            "책 상세 메세지", "책 위치");
+        postWithToken("/api/books/", token, bookRegisterRequest);
+
+        BookRegisterRequest bookRegisterRequest2 = new BookRegisterRequest("책 제목2", "image_url2",
+            "책 상세 메세지2", "책 위치2");
+        postWithToken("/api/books/", token, bookRegisterRequest2);
+
+        // when
+        ExtractableResponse<Response> response = get("/api/books");
+
+        // then
+        List<BookResponse> expected = List.of(
+            new BookResponse(nickname, "책 제목", "image_url",
+            "책 상세 메세지", "책 위치"),
+            new BookResponse(nickname, "책 제목2", "image_url2",
+                "책 상세 메세지2", "책 위치2"));
+
+        List<BookResponse> actual = response.body().jsonPath().getList(".", BookResponse.class);
+
+        assertThat(actual).usingRecursiveComparison()
+            .isEqualTo(expected);
     }
 
     private String getTokenWithLogin(LoginMemberRequest loginMemberRequest) {

--- a/src/test/java/sogorae/billage/repository/HibernateBookRepositoryTest.java
+++ b/src/test/java/sogorae/billage/repository/HibernateBookRepositoryTest.java
@@ -2,11 +2,15 @@ package sogorae.billage.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
 import sogorae.billage.domain.Book;
 import sogorae.billage.domain.Member;
 import sogorae.billage.exception.BookNotFoundException;
@@ -17,6 +21,9 @@ class HibernateBookRepositoryTest {
 
     @Autowired
     private HibernateBookRepository bookRepository;
+
+    @Autowired
+    private HibernateMemberRepository memberRepository;
 
     @Test
     @DisplayName("회원 저장 기능을 검증한다.")
@@ -54,5 +61,27 @@ class HibernateBookRepositoryTest {
         assertThatThrownBy(() -> bookRepository.findById(99L))
             .isInstanceOf(BookNotFoundException.class)
             .hasMessage("해당 책이 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("전체 책을 조회한다.")
+    void findAll() {
+        // given
+        Member owner = new Member("email@naver.com", "nickname", "password");
+        memberRepository.save(owner);
+
+        Book book = new Book(owner, "책 제목", "image_url", "책 상세 메세지", "책 위치");
+        Book book2 = new Book(owner, "책 제목2", "image_url2", "책 상세 메세지2", "책 위치2");
+        bookRepository.save(book);
+        bookRepository.save(book2);
+
+        // when
+        List<Book> books = bookRepository.findAll();
+
+        // then
+        Assertions.assertAll(
+            () -> assertThat(book).isIn(books),
+            () -> assertThat(book2).isIn(books)
+        );
     }
 }

--- a/src/test/java/sogorae/billage/service/BookServiceTest.java
+++ b/src/test/java/sogorae/billage/service/BookServiceTest.java
@@ -3,6 +3,9 @@ package sogorae.billage.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,13 +14,14 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.transaction.annotation.Transactional;
 import sogorae.billage.domain.Book;
+import sogorae.billage.domain.Member;
 import sogorae.billage.dto.BookRegisterRequest;
 import sogorae.billage.dto.MemberSignUpRequest;
 import sogorae.billage.exception.BookInvalidException;
 import sogorae.billage.exception.BookNotFoundException;
 
 @SpringBootTest
-@Transactional
+@Transactional()
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 class BookServiceTest {
 
@@ -152,5 +156,28 @@ class BookServiceTest {
         assertThatThrownBy(() -> bookService.findById(99L))
             .isInstanceOf(BookNotFoundException.class)
             .hasMessage("해당 책이 존재하지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("전체 책을 조회한다.")
+    void findAll() {
+        // given
+        Member member = new Member("email@naver.com", "nickname", "password");
+        MemberSignUpRequest signUpRequest = new MemberSignUpRequest(
+            member.getEmail(), member.getNickname(), member.getPassword());
+        memberService.save(signUpRequest);
+        BookRegisterRequest request = new BookRegisterRequest("책 제목", "image_url", "책 상세 메세지", "책 위치");
+        BookRegisterRequest request2 = new BookRegisterRequest("책 제목2", "image_url2", "책 상세 메세지2", "책 위치2");
+        bookService.register(request, signUpRequest.getEmail());
+        bookService.register(request2, signUpRequest.getEmail());
+
+        // when
+        List<Book> books = bookService.findAll();
+
+        // then
+        Assertions.assertAll(
+            () -> assertThat(request.getTitle()).isEqualTo(books.get(0).getTitle()),
+            () -> assertThat(request2.getTitle()).isEqualTo(books.get(1).getTitle())
+        );
     }
 }


### PR DESCRIPTION
1. JPA 한 Transaction 내에서 객체의 동일성이 유지된다. 이는 테스트에서도 동일하게 적용된다. FindAll을 해서 조회한 객체와 저장 이전 객체는 `동일하게` 취급된다. 그러나 테스트의 Transaction 내에서 메서드의 Transaction이 종료되는 경우는 동일성이 유지되지 않는다. 

2. interceptor 예외 상황 처리 중 prehandle method 에서 url String 을 equals  비교하면 ant pattern 적용 안된다. 당연한데 삽질 좀 했다. 